### PR TITLE
Corrige bug no require de Request em TransparentRequest

### DIFF
--- a/lib/transparent_request.rb
+++ b/lib/transparent_request.rb
@@ -1,3 +1,5 @@
+require "request"
+
 module MyMoip
   class TransparentRequest < Request
 


### PR DESCRIPTION
Algumas vezes a classe TransparentRequest é carregada antes de sua superclasse Request, para solucionar o problema, adicionei o require de Request no arquivo do TransparentRequest, para garantir que a classe sempre esteja carregada naquele momento.
