### PR TITLE
Ordem de require

### DIFF
--- a/lib/mymoip.rb
+++ b/lib/mymoip.rb
@@ -18,7 +18,7 @@ module MyMoip
 end
 
 $LOAD_PATH << "./lib/mymoip"
-Dir[File.dirname(__FILE__) + "/mymoip/*.rb"].each { |file| require file }
+Dir[File.dirname(__FILE__) + "./mymoip/*.rb"].each { |file| require file }
 
 MyMoip.environment = "sandbox"
 MyMoip.logger = Logger.new(STDOUT)

--- a/lib/mymoip.rb
+++ b/lib/mymoip.rb
@@ -18,7 +18,13 @@ module MyMoip
 end
 
 $LOAD_PATH << "./lib/mymoip"
-Dir[File.dirname(__FILE__) + "./mymoip/*.rb"].each { |file| require file }
 
+require 'mymoip/request'
+
+files = Dir[File.dirname(__FILE__) + "/mymoip/*.rb"]
+after_request = files.reject! { |f| f.include?('/request.rb') }
+
+after_request.each { |f| require f }
+ 
 MyMoip.environment = "sandbox"
 MyMoip.logger = Logger.new(STDOUT)


### PR DESCRIPTION
Prevenção caso se tente carregar os arquivos antes das dependências.

No caso, em meu sistema, estava-se tentando carregar os arquivos `transparent_request.rb` e `payment_request.rb` antes que o `request.rb` tivesse sido carregado. O que ocasiona um erro.

```
/home/developer5/.rvm/gems/ruby-1.9.2-p290@proj/gems/activesupport-3.2.3/lib/active_support/dependencies.rb:251:in `require': no such file to load -- request (LoadError)
  from /home/developer5/.rvm/gems/ruby-1.9.2-p290@proj/gems/activesupport-3.2.3/lib/active_support/dependencies.rb:251:in `block in require'
  from /home/developer5/.rvm/gems/ruby-1.9.2-p290@proj/gems/activesupport-3.2.3/lib/active_support/dependencies.rb:236:in `load_dependency'
  from /home/developer5/.rvm/gems/ruby-1.9.2-p290@proj/gems/activesupport-3.2.3/lib/active_support/dependencies.rb:251:in `require'
  from /home/developer5/.rvm/gems/ruby-1.9.2-p290@proj/gems/mymoip-0.2.1/lib/mymoip.rb:25:in `<top (required)>'
  from /home/developer5/.rvm/gems/ruby-1.9.2-p290@global/gems/bundler-1.2.1/lib/bundler/runtime.rb:68:in `require'
  from /home/developer5/.rvm/gems/ruby-1.9.2-p290@global/gems/bundler-1.2.1/lib/bundler/runtime.rb:68:in `block (2 levels) in require'
  from /home/developer5/.rvm/gems/ruby-1.9.2-p290@global/gems/bundler-1.2.1/lib/bundler/runtime.rb:66:in `each'
  from /home/developer5/.rvm/gems/ruby-1.9.2-p290@global/gems/bundler-1.2.1/lib/bundler/runtime.rb:66:in `block in require'
  from /home/developer5/.rvm/gems/ruby-1.9.2-p290@global/gems/bundler-1.2.1/lib/bundler/runtime.rb:55:in `each'
  from /home/developer5/.rvm/gems/ruby-1.9.2-p290@global/gems/bundler-1.2.1/lib/bundler/runtime.rb:55:in `require'
  from /home/developer5/.rvm/gems/ruby-1.9.2-p290@global/gems/bundler-1.2.1/lib/bundler.rb:128:in `require'
  from /home/developer5/Projects/WUEBA/config/application.rb:8:in `<top (required)>'
  from /home/developer5/.rvm/gems/ruby-1.9.2-p290@proj/gems/railties-3.2.3/lib/rails/commands.rb:53:in `require'
  from /home/developer5/.rvm/gems/ruby-1.9.2-p290@proj/gems/railties-3.2.3/lib/rails/commands.rb:53:in `block in <top (required)>'
  from /home/developer5/.rvm/gems/ruby-1.9.2-p290@proj/gems/railties-3.2.3/lib/rails/commands.rb:50:in `tap'
  from /home/developer5/.rvm/gems/ruby-1.9.2-p290@proj/gems/railties-3.2.3/lib/rails/commands.rb:50:in `<top (required)>'
  from script/rails:6:in `require'
  from script/rails:6:in `<main>'
```

Ops! era para anexar somente o segundo commit mas não consegui selecionar antes de enviar. :(
