### PR TITLE
Commission feature

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,5 +11,3 @@ doc
 # jeweler generated
 pkg
 
-#ruby mine
-.idea

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,6 @@ doc
 
 # jeweler generated
 pkg
+
+#ruby mine
+.idea

--- a/README.md
+++ b/README.md
@@ -85,6 +85,29 @@ payment_request.api_call(credit_card_payment, token: transparent_request.token)
 payment_request.success?
 ```
 
+**Commission Feature**
+
+```ruby
+#Create an array of commissions
+commissions = [MyMoip::Commission.new {
+  reason: 'Because we can',
+  commissioned: 'commissioned_login_moip',
+  fixed_value: 23.4,
+  percentage_value: 20
+}]
+
+instruction = MyMoip::Instruction.new(
+  id: "instruction_id_defined_by_you",
+  payment_reason: "Order in Buy Everything Store",
+  values: [100.0],
+  payer: payer,
+  commissions: commissions,
+  fee_payer: 'fee_payer_login_moip', # Not mandatory
+  payment_receiver: 'payment_receiver_login_moip', #Not mandatory
+  payment_receiver_nickname: 'payment_receiver_nickname'  #Not mandatory
+)
+```
+
 Documentation
 -------------
 

--- a/README.md
+++ b/README.md
@@ -88,10 +88,9 @@ payment_request.success?
 **Commission Feature**
 
 ```ruby
-#Create an array of commissions
 commissions = [MyMoip::Commission.new {
   reason: 'Because we can',
-  commissioned: 'commissioned_login_moip',
+  commissioned: 'commissioned_moip_login',
   fixed_value: 23.4,
   percentage_value: 20
 }]
@@ -102,8 +101,8 @@ instruction = MyMoip::Instruction.new(
   values: [100.0],
   payer: payer,
   commissions: commissions,
-  fee_payer: 'fee_payer_login_moip', # Not mandatory
-  payment_receiver: 'payment_receiver_login_moip', #Not mandatory
+  fee_payer: 'fee_payer_moip_login', # Not mandatory
+  payment_receiver: 'payment_receiver_moip_login', #Not mandatory
   payment_receiver_nickname: 'payment_receiver_nickname'  #Not mandatory
 )
 ```

--- a/README.md
+++ b/README.md
@@ -88,12 +88,12 @@ payment_request.success?
 **Commission Feature**
 
 ```ruby
-commissions = [MyMoip::Commission.new {
+commissions = [MyMoip::Commission.new({
   reason: 'Because we can',
-  commissioned: 'commissioned_moip_login',
+  receiver_login: 'commissioned_moip_login',
   fixed_value: 23.4,
   percentage_value: 20
-}]
+})]
 
 instruction = MyMoip::Instruction.new(
   id: "instruction_id_defined_by_you",
@@ -101,9 +101,9 @@ instruction = MyMoip::Instruction.new(
   values: [100.0],
   payer: payer,
   commissions: commissions,
-  fee_payer: 'fee_payer_moip_login', # Not mandatory
-  payment_receiver: 'payment_receiver_moip_login', #Not mandatory
-  payment_receiver_nickname: 'payment_receiver_nickname'  #Not mandatory
+  fee_payer_login: 'fee_payer_moip_login', # Not mandatory
+  payment_receiver_login: 'payment_receiver_moip_login', #Not mandatory
+  payment_receiver_name: 'payment_receiver_nickname'  #Not mandatory
 )
 ```
 

--- a/lib/mymoip/commission.rb
+++ b/lib/mymoip/commission.rb
@@ -1,9 +1,9 @@
 module MyMoip
   class Commission
     include ActiveModel::Validations
-    attr_accessor :reason, :commissioned, :fixed_value, :percentage_value
+    attr_accessor :reason, :receiver_login, :fixed_value, :percentage_value
 
-    validates_presence_of :reason, :commissioned
+    validates_presence_of :reason, :receiver_login
     validates_presence_of :fixed_value, if: -> {percentage_value.nil?}
     validates_presence_of :percentage_value, if: -> {fixed_value.nil?}
     validates_numericality_of :fixed_value, greater_than_or_equal_to: 0, allow_nil:true
@@ -11,7 +11,7 @@ module MyMoip
 
     def initialize(args)
       self.reason = args[:reason]
-      self.commissioned = args[:commissioned]
+      self.receiver_login = args[:receiver_login]
       self.fixed_value = args[:fixed_value]
       self.percentage_value = args[:percentage_value]
     end
@@ -26,7 +26,7 @@ module MyMoip
 
       root.Comissionamento do |n1|
         n1.Razao reason
-        n1.Comissionado {|n2| n2.LoginMoIP(commissioned)}
+        n1.Comissionado {|n2| n2.LoginMoIP(receiver_login)}
         n1.ValorFixo fixed_value  if fixed_value
         n1.ValorPercentual percentage_value if percentage_value
       end

--- a/lib/mymoip/commission.rb
+++ b/lib/mymoip/commission.rb
@@ -6,7 +6,6 @@ module MyMoip
     validates_presence_of :reason, :commissioned
     validates_presence_of :fixed_value, if: -> {percentage_value == nil}
     validates_presence_of :percentage_value, if: -> {fixed_value == nil}
-    validate :only_a_single_value
     validates_numericality_of :fixed_value, greater_than_or_equal_to: 0, allow_nil:true
     validates_numericality_of :percentage_value, greater_than_or_equal_to:0, less_than_or_equal_to:100, allow_nil:true
 
@@ -15,13 +14,6 @@ module MyMoip
       self.commissioned = args[:commissioned]
       self.fixed_value = args[:fixed_value]
       self.percentage_value = args[:percentage_value]
-    end
-
-    def only_a_single_value
-      if fixed_value != nil and percentage_value != nil
-        errors.add :fixed_value, "Only a single value. Choose between fixed or percentage value"
-        errors.add :percentage_value, "Only a single value. Choose between fixed or percentage value"
-      end
     end
 
     def to_xml(root = nil)

--- a/lib/mymoip/commission.rb
+++ b/lib/mymoip/commission.rb
@@ -24,10 +24,14 @@ module MyMoip
       end
     end
 
-    def to_xml
+    def to_xml(root = nil)
       raise ArgumentError, "Invalid params for Commission" if invalid?
-      xml  = ""
-      root = Builder::XmlMarkup.new(target: xml)
+
+      if root.nil?
+        xml  = ""
+        root ||= Builder::XmlMarkup.new(target: xml)
+      end
+
       root.Comissionamento do |n1|
         n1.Razao reason
         n1.Comissionado {|n2| n2.LoginMoIP(commissioned)}

--- a/lib/mymoip/commission.rb
+++ b/lib/mymoip/commission.rb
@@ -25,10 +25,10 @@ module MyMoip
       end
 
       root.Comissionamento do |n1|
-        n1.Razao reason
+        n1.Razao(reason)
         n1.Comissionado {|n2| n2.LoginMoIP(receiver_login)}
-        n1.ValorFixo fixed_value  if fixed_value
-        n1.ValorPercentual percentage_value if percentage_value
+        n1.ValorFixo(fixed_value)  if fixed_value
+        n1.ValorPercentual(percentage_value) if percentage_value
       end
       xml
     end

--- a/lib/mymoip/commission.rb
+++ b/lib/mymoip/commission.rb
@@ -24,5 +24,18 @@ module MyMoip
       end
     end
 
+    def to_xml
+      raise ArgumentError, "Invalid params for Commission" if invalid?
+      xml  = ""
+      root = Builder::XmlMarkup.new(target: xml)
+      root.Comissionamento do |n1|
+        n1.Razao reason
+        n1.Comissionado {|n2| n2.LoginMoIP(commissioned)}
+        n1.ValorFixo fixed_value  if fixed_value
+        n1.ValorPercentual percentage_value if percentage_value
+      end
+      xml
+    end
+
   end
 end

--- a/lib/mymoip/commission.rb
+++ b/lib/mymoip/commission.rb
@@ -4,8 +4,8 @@ module MyMoip
     attr_accessor :reason, :commissioned, :fixed_value, :percentage_value
 
     validates_presence_of :reason, :commissioned
-    validates_presence_of :fixed_value, if: -> {percentage_value == nil}
-    validates_presence_of :percentage_value, if: -> {fixed_value == nil}
+    validates_presence_of :fixed_value, if: -> {percentage_value.nil?}
+    validates_presence_of :percentage_value, if: -> {fixed_value.nil?}
     validates_numericality_of :fixed_value, greater_than_or_equal_to: 0, allow_nil:true
     validates_numericality_of :percentage_value, greater_than_or_equal_to:0, less_than_or_equal_to:100, allow_nil:true
 

--- a/lib/mymoip/commission.rb
+++ b/lib/mymoip/commission.rb
@@ -1,0 +1,28 @@
+module MyMoip
+  class Commission
+    include ActiveModel::Validations
+    attr_accessor :reason, :commissioned, :fixed_value, :percentage_value
+
+    validates_presence_of :reason, :commissioned
+    validates_presence_of :fixed_value, if: -> {percentage_value == nil}
+    validates_presence_of :percentage_value, if: -> {fixed_value == nil}
+    validate :only_a_single_value
+    validates_numericality_of :fixed_value, greater_than_or_equal_to: 0, allow_nil:true
+    validates_numericality_of :percentage_value, greater_than_or_equal_to:0, less_than_or_equal_to:100, allow_nil:true
+
+    def initialize(args)
+      self.reason = args[:reason]
+      self.commissioned = args[:commissioned]
+      self.fixed_value = args[:fixed_value]
+      self.percentage_value = args[:percentage_value]
+    end
+
+    def only_a_single_value
+      if fixed_value != nil and percentage_value != nil
+        errors.add :fixed_value, "Only a single value. Choose between fixed or percentage value"
+        errors.add :percentage_value, "Only a single value. Choose between fixed or percentage value"
+      end
+    end
+
+  end
+end

--- a/lib/mymoip/instruction.rb
+++ b/lib/mymoip/instruction.rb
@@ -47,14 +47,13 @@ module MyMoip
     end
 
     def commissions_sum
-      commissions.inject(0) do |sum, c|
+      commissions.reduce(0) do |sum, c|
         sum + (c.fixed_value || 0) + values_sum * ( (c.percentage_value || 0) / 100.0)
       end
     end
 
     def values_sum
-      return values.inject(0){|sum,value| sum + value} if values
-      return 0
+      values ? values.reduce(0) {|sum,value| sum + value} : 0
     end
 
     protected
@@ -66,7 +65,7 @@ module MyMoip
 
     def payment_receiver_presence_in_commissions
       errors.add :payment_receiver_login,
-                 "Instruction invalid. Payment receiver can't be commissioned" if commissions.detect {|c| c.commissioned == payment_receiver_login}
+                 "Instruction invalid. Payment receiver can't be commissioned" if commissions.find {|c| c.receiver_login == payment_receiver_login}
     end
 
     def commissions_to_xml(node)

--- a/lib/mymoip/instruction.rb
+++ b/lib/mymoip/instruction.rb
@@ -6,7 +6,6 @@ module MyMoip
                     :commissions, :fee_payer, :payment_receiver, :payment_receiver_nickname
 
     validates_presence_of :id, :payment_reason, :values, :payer
-    validates_presence_of :payment_receiver_nickname, if: -> {self.payment_receiver}
     validate :commissions_value_must_be_lesser_than_values
     validate :payment_receiver_presence_in_commissions
 

--- a/lib/mymoip/instruction.rb
+++ b/lib/mymoip/instruction.rb
@@ -2,7 +2,8 @@ module MyMoip
   class Instruction
     include ActiveModel::Validations
 
-    attr_accessor :id, :payment_reason, :values, :payer
+    attr_accessor :id, :payment_reason, :values, :payer,
+                    :commissions, :fee_payer, :payment_receiver, :payment_receiver_nickname
 
     validates_presence_of :id, :payment_reason, :values, :payer
 
@@ -11,11 +12,16 @@ module MyMoip
       self.payment_reason = attrs[:payment_reason] if attrs.has_key?(:payment_reason)
       self.values         = attrs[:values]         if attrs.has_key?(:values)
       self.payer          = attrs[:payer]          if attrs.has_key?(:payer)
+      self.commissions = attrs[:commissions] || []
+      self.fee_payer = attrs[:fee_payer] if attrs.has_key?(:fee_payer)
+      self.payment_receiver = attrs[:payment_receiver] if attrs.has_key?(:payment_receiver)
+      self.payment_receiver_nickname = attrs[:payment_receiver_nickname] if attrs.has_key?(:payment_receiver_nickname)
     end
 
     def to_xml(root = nil)
       raise ArgumentError, 'Invalid payer' if payer.invalid?
       raise ArgumentError, 'Invalid params for instruction' if self.invalid?
+      raise ArgumentError, 'Instruction has an invalid commission' if self.commissions.detect {|c| c.invalid? }
 
       xml  = ""
       root = Builder::XmlMarkup.new(target: xml)
@@ -27,11 +33,32 @@ module MyMoip
             @values.each { |v| n3.Valor("%.2f" % v, moeda: "BRL") }
           end
           n2.IdProprio(@id)
+
+          commissions_to_xml n2  if !commissions.empty?
+          payment_receiver_to_xml n2 if payment_receiver
+
           n2.Pagador { |n3| @payer.to_xml(n3) }
         end
       end
 
       xml
     end
+
+    protected
+
+    def commissions_to_xml(node)
+      node.Comissoes do |n|
+        commissions.each {|c| c.to_xml(n)}
+        n.PagadorTaxa {|pt| pt.LoginMoIP(fee_payer)} if fee_payer
+      end
+    end
+
+    def payment_receiver_to_xml(node)
+      node.Recebedor do |n|
+        n.LoginMoIP(self.payment_receiver)
+        n.Apelido(self.payment_receiver_nickname)
+      end
+    end
+
   end
 end

--- a/lib/mymoip/instruction.rb
+++ b/lib/mymoip/instruction.rb
@@ -3,7 +3,7 @@ module MyMoip
     include ActiveModel::Validations
 
     attr_accessor :id, :payment_reason, :values, :payer,
-                    :commissions, :fee_payer, :payment_receiver, :payment_receiver_nickname
+                    :commissions, :fee_payer_login, :payment_receiver_login, :payment_receiver_name
 
     validates_presence_of :id, :payment_reason, :values, :payer
     validate :commissions_value_must_be_lesser_than_values
@@ -15,9 +15,9 @@ module MyMoip
       self.values         = attrs[:values]         if attrs.has_key?(:values)
       self.payer          = attrs[:payer]          if attrs.has_key?(:payer)
       self.commissions = attrs[:commissions] || []
-      self.fee_payer = attrs[:fee_payer] if attrs.has_key?(:fee_payer)
-      self.payment_receiver = attrs[:payment_receiver] if attrs.has_key?(:payment_receiver)
-      self.payment_receiver_nickname = attrs[:payment_receiver_nickname] if attrs.has_key?(:payment_receiver_nickname)
+      self.fee_payer_login = attrs[:fee_payer_login] if attrs.has_key?(:fee_payer_login)
+      self.payment_receiver_login = attrs[:payment_receiver_login] if attrs.has_key?(:payment_receiver_login)
+      self.payment_receiver_name = attrs[:payment_receiver_name] if attrs.has_key?(:payment_receiver_name)
     end
 
     def to_xml(root = nil)
@@ -37,7 +37,7 @@ module MyMoip
           n2.IdProprio(@id)
 
           commissions_to_xml n2  if !commissions.empty?
-          payment_receiver_to_xml n2 if payment_receiver
+          payment_receiver_to_xml n2 if payment_receiver_login
 
           n2.Pagador { |n3| @payer.to_xml(n3) }
         end
@@ -65,21 +65,21 @@ module MyMoip
     end
 
     def payment_receiver_presence_in_commissions
-      errors.add :payment_receiver,
-                 "Instruction invalid. Payment receiver can't be commissioned" if commissions.detect {|c| c.commissioned == payment_receiver}
+      errors.add :payment_receiver_login,
+                 "Instruction invalid. Payment receiver can't be commissioned" if commissions.detect {|c| c.commissioned == payment_receiver_login}
     end
 
     def commissions_to_xml(node)
       node.Comissoes do |n|
         commissions.each {|c| c.to_xml(n)}
-        n.PagadorTaxa {|pt| pt.LoginMoIP(fee_payer)} if fee_payer
+        n.PagadorTaxa {|pt| pt.LoginMoIP(fee_payer_login)} if fee_payer_login
       end
     end
 
     def payment_receiver_to_xml(node)
       node.Recebedor do |n|
-        n.LoginMoIP(self.payment_receiver)
-        n.Apelido(self.payment_receiver_nickname)
+        n.LoginMoIP(self.payment_receiver_login)
+        n.Apelido(self.payment_receiver_name)
       end
     end
 

--- a/lib/mymoip/instruction.rb
+++ b/lib/mymoip/instruction.rb
@@ -8,6 +8,7 @@ module MyMoip
     validates_presence_of :id, :payment_reason, :values, :payer
     validates_presence_of :payment_receiver_nickname, if: -> {self.payment_receiver}
     validate :commissions_value_must_be_lesser_than_values
+    validate :payment_receiver_presence_in_commissions
 
     def initialize(attrs)
       self.id             = attrs[:id]             if attrs.has_key?(:id)
@@ -60,8 +61,13 @@ module MyMoip
     protected
 
     def commissions_value_must_be_lesser_than_values
-        errors.add :commissions,
-                   "Instruction invalid. Commissions value is greater than instruction value" if commissions_sum > values_sum
+      errors.add :commissions,
+                 "Instruction invalid. Commissions value sum is greater than instruction value sum" if commissions_sum > values_sum
+    end
+
+    def payment_receiver_presence_in_commissions
+      errors.add :payment_receiver,
+                 "Instruction invalid. Payment receiver can't be commissioned" if commissions.detect {|c| c.commissioned == payment_receiver}
     end
 
     def commissions_to_xml(node)

--- a/test/fixtures/fixture.rb
+++ b/test/fixtures/fixture.rb
@@ -44,7 +44,7 @@ class Fixture
   def self.commission(params = {})
     params = {
         reason: 'Because we can',
-        commissioned: 'commissioned_indentifier',
+        receiver_login: 'commissioned_indentifier',
         fixed_value: 23.4
     }.merge(params)
     MyMoip::Commission.new(params)

--- a/test/fixtures/fixture.rb
+++ b/test/fixtures/fixture.rb
@@ -41,4 +41,13 @@ class Fixture
     MyMoip::CreditCard.new(params)
   end
 
+  def self.commission(params = {})
+    params = {
+        reason: 'Because we can',
+        commissioned: 'commissioned_indentifier',
+        fixed_value: 23.4
+    }.merge(params)
+    MyMoip::Commission.new(params)
+  end
+
 end

--- a/test/fixtures/vcr_cassettes/transparent_request_with_commissions.yml
+++ b/test/fixtures/vcr_cassettes/transparent_request_with_commissions.yml
@@ -29,7 +29,7 @@ http_interactions:
       - text/xml;charset=UTF-8
     body:
       encoding: US-ASCII
-      string: <ns1:EnviarInstrucaoUnicaResponse xmlns:ns1="http://www.moip.com.br/ws/alpha/"><Resposta><ID>201211281220497180000001185344</ID><Status>Sucesso</Status><Token>E2O0U1W2K1P1D1R2C2E3H0N3L5X3A2E4E3X0X030T090T0ATOKENQUALQUER</Token></Resposta></ns1:EnviarInstrucaoUnicaResponse>
+      string: <ns1:EnviarInstrucaoUnicaResponse xmlns:ns1="http://www.moip.com.br/ws/alpha/"><Resposta><ID>YOUR_REQUEST_ID</ID><Status>Sucesso</Status><Token>YOUR_MOIP_TOKEN</Token></Resposta></ns1:EnviarInstrucaoUnicaResponse>
     http_version: 
   recorded_at: Wed, 28 Nov 2012 14:17:23 GMT
 recorded_with: VCR 2.2.5

--- a/test/fixtures/vcr_cassettes/transparent_request_with_commissions.yml
+++ b/test/fixtures/vcr_cassettes/transparent_request_with_commissions.yml
@@ -29,7 +29,7 @@ http_interactions:
       - text/xml;charset=UTF-8
     body:
       encoding: US-ASCII
-      string: <ns1:EnviarInstrucaoUnicaResponse xmlns:ns1="http://www.moip.com.br/ws/alpha/"><Resposta><ID>201211281220497180000001185344</ID><Status>Sucesso</Status><Token>K2U001J261A1I2P841R2X2K0W469Y7J1L8D0J0Y0N020V0R1G1C8T5U3E4B4</Token></Resposta></ns1:EnviarInstrucaoUnicaResponse>
+      string: <ns1:EnviarInstrucaoUnicaResponse xmlns:ns1="http://www.moip.com.br/ws/alpha/"><Resposta><ID>201211281220497180000001185344</ID><Status>Sucesso</Status><Token>E2O0U1W2K1P1D1R2C2E3H0N3L5X3A2E4E3X0X030T090T0ATOKENQUALQUER</Token></Resposta></ns1:EnviarInstrucaoUnicaResponse>
     http_version: 
   recorded_at: Wed, 28 Nov 2012 14:17:23 GMT
 recorded_with: VCR 2.2.5

--- a/test/fixtures/vcr_cassettes/transparent_request_with_commissions.yml
+++ b/test/fixtures/vcr_cassettes/transparent_request_with_commissions.yml
@@ -1,0 +1,35 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://YOUR_MOIP_TOKEN:YOUR_MOIP_KEY@desenvolvedor.moip.com.br/sandbox/ws/alpha/EnviarInstrucao/Unica
+    body:
+      encoding: US-ASCII
+      string: <EnviarInstrucao><InstrucaoUnica TipoValidacao="Transparente"><Razao>some
+        payment_reason</Razao><Valores><Valor moeda="BRL">100.00</Valor><Valor moeda="BRL">200.00</Valor></Valores><IdProprio>your_own_instruction_id</IdProprio><Comissoes><Comissionamento><Razao>Because
+        we can</Razao><Comissionado><LoginMoIP>commissioned_id</LoginMoIP></Comissionado><ValorFixo>5</ValorFixo></Comissionamento></Comissoes><Pagador><Nome>Juquinha
+        da Rocha</Nome><Email>juquinha@rocha.com</Email><IdPagador>your_own_payer_id</IdPagador><EnderecoCobranca><Logradouro>Felipe
+        Neri</Logradouro><Numero>406</Numero><Complemento>Sala 501</Complemento><Bairro>Auxiliadora</Bairro><Cidade>Porto
+        Alegre</Cidade><Estado>RS</Estado><Pais>BRA</Pais><CEP>90440-150</CEP><TelefoneFixo>(51)3040-5060</TelefoneFixo></EnderecoCobranca></Pagador></InstrucaoUnica></EnviarInstrucao>
+    headers: {}
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 28 Nov 2012 14:20:49 GMT
+      Server:
+      - Apache/2.2.23 (CentOS)
+      Content-Length:
+      - '273'
+      Vary:
+      - Accept-Encoding
+      Content-Type:
+      - text/xml;charset=UTF-8
+    body:
+      encoding: US-ASCII
+      string: <ns1:EnviarInstrucaoUnicaResponse xmlns:ns1="http://www.moip.com.br/ws/alpha/"><Resposta><ID>201211281220497180000001185344</ID><Status>Sucesso</Status><Token>K2U001J261A1I2P841R2X2K0W469Y7J1L8D0J0Y0N020V0R1G1C8T5U3E4B4</Token></Resposta></ns1:EnviarInstrucaoUnicaResponse>
+    http_version: 
+  recorded_at: Wed, 28 Nov 2012 14:17:23 GMT
+recorded_with: VCR 2.2.5

--- a/test/test_commission.rb
+++ b/test/test_commission.rb
@@ -27,7 +27,7 @@ class TestCommission < Test::Unit::TestCase
            "should be invalid without a commissioned"
   end
 
-  def test_validate_presence_of_fixed_value_xor_percentage_value
+  def test_validate_presence_of_fixed_value_or_percentage_value
     subject = Fixture.commission(fixed_value: nil, percentage_value: nil)
 
     assert subject.invalid? && subject.errors[:fixed_value].present?,
@@ -37,11 +37,16 @@ class TestCommission < Test::Unit::TestCase
            "should be invalid without a percentage value"
 
     subject.fixed_value = 2
-    subject.percentage_value = 2
+    assert subject.valid?, "should be valid with only fixed value set"
 
-    assert subject.invalid? && subject.errors[:percentage_value].present? && subject.errors[:fixed_value].present?,
-           "should be invalid with fixed and percentage value set"
+    subject.fixed_value = nil
+    subject.percentage_value = 2
+    assert subject.valid?, "should be valid with only percentage value set"
+
+    subject.fixed_value = subject.percentage_value
+    assert subject.valid?, "should be valid with both values set"
   end
+
 
   def test_validate_numericality_of_fixed_value
     subject = Fixture.commission fixed_value: "I'm not a number"

--- a/test/test_commission.rb
+++ b/test/test_commission.rb
@@ -8,7 +8,7 @@ class TestCommission < Test::Unit::TestCase
         fixed_value: 23.5,
         percentage_value: 12.67
     }
-    subject = MyMoip::Commission.new params
+    subject = MyMoip::Commission.new(params)
     assert_equal params[:reason], subject.reason
     assert_equal params[:receiver_login], subject.receiver_login
     assert_equal params[:fixed_value], subject.fixed_value

--- a/test/test_commission.rb
+++ b/test/test_commission.rb
@@ -70,4 +70,28 @@ class TestCommission < Test::Unit::TestCase
            "should be invalid if not within (0..100)"
   end
 
+  def test_xml_format_with_fixed_value
+    subject = Fixture.commission fixed_value: 5
+    expected_format = <<XML
+<Comissionamento><Razao>Because we can</Razao><Comissionado><LoginMoIP>commissioned_indentifier</LoginMoIP></Comissionado><ValorFixo>5</ValorFixo></Comissionamento>
+XML
+    assert_equal expected_format.rstrip, subject.to_xml
+  end
+
+  def test_xml_format_with_percentage_value
+    subject = Fixture.commission percentage_value: 5, fixed_value: nil
+    expected_format = <<XML
+<Comissionamento><Razao>Because we can</Razao><Comissionado><LoginMoIP>commissioned_indentifier</LoginMoIP></Comissionado><ValorPercentual>5</ValorPercentual></Comissionamento>
+XML
+    assert_equal expected_format.rstrip, subject.to_xml
+  end
+
+  def test_xml_method_raises_exception_when_called_with_invalid_params
+    subject = Fixture.commission
+    subject.stubs(:invalid?).returns(true)
+    assert_raise ArgumentError do
+      subject.to_xml
+    end
+  end
+
 end

--- a/test/test_commission.rb
+++ b/test/test_commission.rb
@@ -1,0 +1,73 @@
+require 'helper'
+
+class TestCommission < Test::Unit::TestCase
+  def test_initialization_and_setters
+    params = {
+        reason: 'Because we can',
+        commissioned: 'comissioned_indentifier',
+        fixed_value: 23.5,
+        percentage_value: 12.67
+    }
+    subject = MyMoip::Commission.new params
+    assert_equal params[:reason], subject.reason
+    assert_equal params[:commissioned], subject.commissioned
+    assert_equal params[:fixed_value], subject.fixed_value
+    assert_equal params[:percentage_value], subject.percentage_value
+  end
+
+  def test_validate_presence_of_reason
+    subject = Fixture.commission(reason: nil)
+    assert subject.invalid? && subject.errors[:reason].present?,
+           "should be invalid without a reason"
+  end
+
+  def test_validate_presence_of_commissioned
+    subject = Fixture.commission(commissioned: nil)
+    assert subject.invalid? && subject.errors[:commissioned].present?,
+           "should be invalid without a commissioned"
+  end
+
+  def test_validate_presence_of_fixed_value_xor_percentage_value
+    subject = Fixture.commission(fixed_value: nil, percentage_value: nil)
+
+    assert subject.invalid? && subject.errors[:fixed_value].present?,
+           "should be invalid without a fixed value"
+
+    assert subject.invalid? && subject.errors[:percentage_value].present?,
+           "should be invalid without a percentage value"
+
+    subject.fixed_value = 2
+    subject.percentage_value = 2
+
+    assert subject.invalid? && subject.errors[:percentage_value].present? && subject.errors[:fixed_value].present?,
+           "should be invalid with fixed and percentage value set"
+  end
+
+  def test_validate_numericality_of_fixed_value
+    subject = Fixture.commission fixed_value: "I'm not a number"
+    assert subject.invalid? && subject.errors[:fixed_value].present?,
+           "should be invalid with a non number"
+  end
+
+  def test_validate_numericality_of_percentage_value
+    subject = Fixture.commission percentage_value: "I'm not a number", fixed_value: nil
+    assert subject.invalid? && subject.errors[:percentage_value].present?,
+           "should be invalid with a non number"
+  end
+
+  def test_validate_positive_number_of_fixed_value
+    subject = Fixture.commission fixed_value: -0.1
+    assert subject.invalid? && subject.errors[:fixed_value].present?,
+           "should be invalid with negative number"
+  end
+
+  def test_validate_percentage_number_of_percentage_value
+    subject = Fixture.commission percentage_value: -0.1, fixed_value: nil
+    assert subject.invalid? && subject.errors[:percentage_value].present?,
+           "should be invalid if not within (0..100)"
+    subject.percentage_value = 100.01
+    assert subject.invalid? && subject.errors[:percentage_value].present?,
+           "should be invalid if not within (0..100)"
+  end
+
+end

--- a/test/test_commission.rb
+++ b/test/test_commission.rb
@@ -4,13 +4,13 @@ class TestCommission < Test::Unit::TestCase
   def test_initialization_and_setters
     params = {
         reason: 'Because we can',
-        commissioned: 'comissioned_indentifier',
+        receiver_login: 'comissioned_indentifier',
         fixed_value: 23.5,
         percentage_value: 12.67
     }
     subject = MyMoip::Commission.new params
     assert_equal params[:reason], subject.reason
-    assert_equal params[:commissioned], subject.commissioned
+    assert_equal params[:receiver_login], subject.receiver_login
     assert_equal params[:fixed_value], subject.fixed_value
     assert_equal params[:percentage_value], subject.percentage_value
   end
@@ -21,10 +21,10 @@ class TestCommission < Test::Unit::TestCase
            "should be invalid without a reason"
   end
 
-  def test_validate_presence_of_commissioned
-    subject = Fixture.commission(commissioned: nil)
-    assert subject.invalid? && subject.errors[:commissioned].present?,
-           "should be invalid without a commissioned"
+  def test_validate_presence_of_receiver_login
+    subject = Fixture.commission(receiver_login: nil)
+    assert subject.invalid? && subject.errors[:receiver_login].present?,
+           "should be invalid without a receiver_login"
   end
 
   def test_validate_presence_of_fixed_value_or_percentage_value

--- a/test/test_instruction.rb
+++ b/test/test_instruction.rb
@@ -127,6 +127,14 @@ XML
     end
   end
 
+  def test_validate_no_presence_of_payment_receiver_in_commissions
+    commissions = [Fixture.commission(commissioned: 'payment_receiver_id')]
+    subject = Fixture.instruction payment_receiver: 'payment_receiver_id', commissions: commissions
+    assert subject.invalid? &&  subject.errors[:payment_receiver].present?,
+           "should be invalid with receiver present on commissions"
+
+  end
+
   def test_validate_presence_of_payment_receiver_nickname
     subject = Fixture.instruction payment_receiver: 'payment_receiver_id'
     assert subject.invalid? && subject.errors[:payment_receiver_nickname].present?,

--- a/test/test_instruction.rb
+++ b/test/test_instruction.rb
@@ -127,6 +127,30 @@ XML
     end
   end
 
+  def test_validate_presence_of_payment_receiver_nickname
+    subject = Fixture.instruction payment_receiver: 'payment_receiver_id'
+    assert subject.invalid? && subject.errors[:payment_receiver_nickname].present?,
+           "should be invalid with payment receiver without nickname"
+  end
+
+  def test_values_sum
+    subject = Fixture.instruction(values: [6, 5])
+    assert_equal 6 + 5, subject.values_sum
+  end
+
+  def test_commissions_sum
+    commissions = [Fixture.commission(fixed_value: 5), Fixture.commission(percentage_value:10, fixed_value:nil)]
+    subject = Fixture.instruction(commissions: commissions, values: [10])
+    assert_equal 6, subject.commissions_sum
+  end
+
+  def test_validate_commissions_sum
+    commissions = [Fixture.commission(fixed_value: 5), Fixture.commission(fixed_value: 5)]
+    subject = Fixture.instruction(commissions: commissions, values: [6])
+    assert subject.invalid? && subject.errors[:commissions].present?,
+           "should be invalid with commissions sum greater than values sum"
+  end
+
   def test_validate_presence_of_id_attribute
     subject = Fixture.instruction
     subject.id = nil

--- a/test/test_instruction.rb
+++ b/test/test_instruction.rb
@@ -10,9 +10,9 @@ class TestInstruction < Test::Unit::TestCase
       values: [100.0, 200.0],
       payer: payer,
       commissions: commissions,
-      fee_payer: "fee_payer_indentifier",
-      payment_receiver: "payment_receiver_indentifier",
-      payment_receiver_nickname: "nick_fury"
+      fee_payer_login: "fee_payer_login",
+      payment_receiver_login: "payment_receiver_login",
+      payment_receiver_name: "nick_fury"
     )
 
     assert_equal "some id", instruction.id
@@ -20,9 +20,9 @@ class TestInstruction < Test::Unit::TestCase
     assert_equal [100.0, 200.0], instruction.values
     assert_equal payer, instruction.payer
     assert_equal commissions, instruction.commissions
-    assert_equal "fee_payer_indentifier", instruction.fee_payer
-    assert_equal "payment_receiver_indentifier", instruction.payment_receiver
-    assert_equal "nick_fury", instruction.payment_receiver_nickname
+    assert_equal "fee_payer_login", instruction.fee_payer_login
+    assert_equal "payment_receiver_login", instruction.payment_receiver_login
+    assert_equal "nick_fury", instruction.payment_receiver_name
   end
 
   def test_should_generate_a_string_when_converting_to_xml
@@ -54,7 +54,7 @@ XML
   def test_xml_format_with_commissions_and_fee_payer
     commissions = [Fixture.commission(fixed_value: 5), Fixture.commission(percentage_value:20,fixed_value:nil)]
     payer       = Fixture.payer
-    instruction = Fixture.instruction(payer: payer, commissions: commissions, fee_payer: 'fee_payer_indentifier')
+    instruction = Fixture.instruction(payer: payer, commissions: commissions, fee_payer_login: 'fee_payer_indentifier')
     expected_format = <<XML
 <EnviarInstrucao><InstrucaoUnica TipoValidacao=\"Transparente\"><Razao>some payment_reason</Razao><Valores><Valor moeda=\"BRL\">100.00</Valor><Valor moeda=\"BRL\">200.00</Valor></Valores><IdProprio>your_own_instruction_id</IdProprio><Comissoes><Comissionamento><Razao>Because we can</Razao><Comissionado><LoginMoIP>commissioned_indentifier</LoginMoIP></Comissionado><ValorFixo>5</ValorFixo></Comissionamento><Comissionamento><Razao>Because we can</Razao><Comissionado><LoginMoIP>commissioned_indentifier</LoginMoIP></Comissionado><ValorPercentual>20</ValorPercentual></Comissionamento><PagadorTaxa><LoginMoIP>fee_payer_indentifier</LoginMoIP></PagadorTaxa></Comissoes><Pagador><Nome>Juquinha da Rocha</Nome><Email>juquinha@rocha.com</Email><IdPagador>your_own_payer_id</IdPagador><EnderecoCobranca><Logradouro>Felipe Neri</Logradouro><Numero>406</Numero><Complemento>Sala 501</Complemento><Bairro>Auxiliadora</Bairro><Cidade>Porto Alegre</Cidade><Estado>RS</Estado><Pais>BRA</Pais><CEP>90440-150</CEP><TelefoneFixo>(51)3040-5060</TelefoneFixo></EnderecoCobranca></Pagador></InstrucaoUnica></EnviarInstrucao>
 XML
@@ -65,8 +65,8 @@ XML
     commissions = [Fixture.commission(fixed_value: 5), Fixture.commission(percentage_value:20,fixed_value:nil)]
     payer       = Fixture.payer
     instruction = Fixture.instruction(payer: payer, commissions: commissions,
-                                      payment_receiver:'payment_receiver_indentifier',
-                                      payment_receiver_nickname: 'nick_fury' )
+                                      payment_receiver_login:'payment_receiver_indentifier',
+                                      payment_receiver_name: 'nick_fury' )
     expected_format = <<XML
 <EnviarInstrucao><InstrucaoUnica TipoValidacao=\"Transparente\"><Razao>some payment_reason</Razao><Valores><Valor moeda=\"BRL\">100.00</Valor><Valor moeda=\"BRL\">200.00</Valor></Valores><IdProprio>your_own_instruction_id</IdProprio><Comissoes><Comissionamento><Razao>Because we can</Razao><Comissionado><LoginMoIP>commissioned_indentifier</LoginMoIP></Comissionado><ValorFixo>5</ValorFixo></Comissionamento><Comissionamento><Razao>Because we can</Razao><Comissionado><LoginMoIP>commissioned_indentifier</LoginMoIP></Comissionado><ValorPercentual>20</ValorPercentual></Comissionamento></Comissoes><Recebedor><LoginMoIP>payment_receiver_indentifier</LoginMoIP><Apelido>nick_fury</Apelido></Recebedor><Pagador><Nome>Juquinha da Rocha</Nome><Email>juquinha@rocha.com</Email><IdPagador>your_own_payer_id</IdPagador><EnderecoCobranca><Logradouro>Felipe Neri</Logradouro><Numero>406</Numero><Complemento>Sala 501</Complemento><Bairro>Auxiliadora</Bairro><Cidade>Porto Alegre</Cidade><Estado>RS</Estado><Pais>BRA</Pais><CEP>90440-150</CEP><TelefoneFixo>(51)3040-5060</TelefoneFixo></EnderecoCobranca></Pagador></InstrucaoUnica></EnviarInstrucao>
 XML
@@ -77,9 +77,9 @@ XML
     commissions = [Fixture.commission(fixed_value: 5), Fixture.commission(percentage_value:20,fixed_value:nil)]
     payer       = Fixture.payer
     instruction = Fixture.instruction(payer: payer, commissions: commissions,
-                                      payment_receiver:'payment_receiver_indentifier',
-                                      payment_receiver_nickname: 'nick_fury',
-                                      fee_payer: 'fee_payer_indentifier')
+                                      payment_receiver_login:'payment_receiver_indentifier',
+                                      payment_receiver_name: 'nick_fury',
+                                      fee_payer_login: 'fee_payer_indentifier')
     expected_format = <<XML
 <EnviarInstrucao><InstrucaoUnica TipoValidacao=\"Transparente\"><Razao>some payment_reason</Razao><Valores><Valor moeda=\"BRL\">100.00</Valor><Valor moeda=\"BRL\">200.00</Valor></Valores><IdProprio>your_own_instruction_id</IdProprio><Comissoes><Comissionamento><Razao>Because we can</Razao><Comissionado><LoginMoIP>commissioned_indentifier</LoginMoIP></Comissionado><ValorFixo>5</ValorFixo></Comissionamento><Comissionamento><Razao>Because we can</Razao><Comissionado><LoginMoIP>commissioned_indentifier</LoginMoIP></Comissionado><ValorPercentual>20</ValorPercentual></Comissionamento><PagadorTaxa><LoginMoIP>fee_payer_indentifier</LoginMoIP></PagadorTaxa></Comissoes><Recebedor><LoginMoIP>payment_receiver_indentifier</LoginMoIP><Apelido>nick_fury</Apelido></Recebedor><Pagador><Nome>Juquinha da Rocha</Nome><Email>juquinha@rocha.com</Email><IdPagador>your_own_payer_id</IdPagador><EnderecoCobranca><Logradouro>Felipe Neri</Logradouro><Numero>406</Numero><Complemento>Sala 501</Complemento><Bairro>Auxiliadora</Bairro><Cidade>Porto Alegre</Cidade><Estado>RS</Estado><Pais>BRA</Pais><CEP>90440-150</CEP><TelefoneFixo>(51)3040-5060</TelefoneFixo></EnderecoCobranca></Pagador></InstrucaoUnica></EnviarInstrucao>
 XML
@@ -129,8 +129,8 @@ XML
 
   def test_validate_no_presence_of_payment_receiver_in_commissions
     commissions = [Fixture.commission(commissioned: 'payment_receiver_id')]
-    subject = Fixture.instruction payment_receiver: 'payment_receiver_id', commissions: commissions
-    assert subject.invalid? &&  subject.errors[:payment_receiver].present?,
+    subject = Fixture.instruction payment_receiver_login: 'payment_receiver_id', commissions: commissions
+    assert subject.invalid? &&  subject.errors[:payment_receiver_login].present?,
            "should be invalid with receiver present on commissions"
 
   end

--- a/test/test_instruction.rb
+++ b/test/test_instruction.rb
@@ -89,7 +89,7 @@ XML
   def test_to_xml_method_raises_exception_when_called_with_some_invalid_comission
     invalid_commission = Fixture.commission
     invalid_commission.stubs(:invalid?).returns(true)
-    subject = Fixture.instruction commissions: [Fixture.commission, invalid_commission]
+    subject = Fixture.instruction(commissions: [Fixture.commission, invalid_commission])
     assert_raise ArgumentError do
       subject.to_xml
     end
@@ -128,8 +128,8 @@ XML
   end
 
   def test_validate_no_presence_of_payment_receiver_in_commissions
-    commissions = [Fixture.commission(commissioned: 'payment_receiver_id')]
-    subject = Fixture.instruction payment_receiver_login: 'payment_receiver_id', commissions: commissions
+    commissions = [Fixture.commission(receiver_login: 'payment_receiver_id')]
+    subject = Fixture.instruction(payment_receiver_login: 'payment_receiver_id', commissions: commissions)
     assert subject.invalid? &&  subject.errors[:payment_receiver_login].present?,
            "should be invalid with receiver present on commissions"
 

--- a/test/test_instruction.rb
+++ b/test/test_instruction.rb
@@ -135,12 +135,6 @@ XML
 
   end
 
-  def test_validate_presence_of_payment_receiver_nickname
-    subject = Fixture.instruction payment_receiver: 'payment_receiver_id'
-    assert subject.invalid? && subject.errors[:payment_receiver_nickname].present?,
-           "should be invalid with payment receiver without nickname"
-  end
-
   def test_values_sum
     subject = Fixture.instruction(values: [6, 5])
     assert_equal 6 + 5, subject.values_sum

--- a/test/test_transparent_request.rb
+++ b/test/test_transparent_request.rb
@@ -61,4 +61,12 @@ class TestTransparentRequest < Test::Unit::TestCase
     end
     assert_equal "201210171118501100000001102691", request.id
   end
+
+  def test_should_provide_the_transaction_id_get_by_the_request_with_commissions_feature
+    request = MyMoip::TransparentRequest.new("some_id")
+    VCR.use_cassette('transparent_request_with_commissions') do
+      request.api_call Fixture.instruction(commissions: [Fixture.commission])
+    end
+    assert_equal "201211281220497180000001185344", request.id
+  end
 end

--- a/test/test_transparent_request.rb
+++ b/test/test_transparent_request.rb
@@ -67,6 +67,6 @@ class TestTransparentRequest < Test::Unit::TestCase
     VCR.use_cassette('transparent_request_with_commissions') do
       request.api_call Fixture.instruction(commissions: [Fixture.commission])
     end
-    assert_equal "201211281220497180000001185344", request.id
+    assert_equal "YOUR_REQUEST_ID", request.id
   end
 end


### PR DESCRIPTION
Olá! Como foi conversado, segue minha contribuição para o projeto.

Esse pull implementa a funcionalidade de adicionar comissionados/recebedores secundários a um instrução de pagamento.
(http://labs.moip.com.br/referencia/secundarios/)

Realizei testes do ambiente de sandbox do Moip e unitários e parece que está tudo ok.

Espero que tenha ficado bom, é a minha primeira contribuição em projetos open source.
