### PR TITLE
Add validation for credit card owner birthday format

### DIFF
--- a/lib/mymoip/credit_card.rb
+++ b/lib/mymoip/credit_card.rb
@@ -29,7 +29,7 @@ module MyMoip
 
     def owner_birthday=(value)
       value = Date.parse(value.to_s) unless value.nil?
-      rescue; ensure
+      rescue ArgumentError; ensure
         @owner_birthday = value
     end
 

--- a/lib/mymoip/credit_card.rb
+++ b/lib/mymoip/credit_card.rb
@@ -14,6 +14,7 @@ module MyMoip
     validates_length_of :security_code, within: 3..4
     validates_format_of :expiration_date, with: /\A(?:(?:0[1-9])|(?:1[02]))\/\d{2}\Z/ # %m/%y
     validates_inclusion_of :logo, in: AVAILABLE_LOGOS
+    validate :owner_birthday_format
 
     def initialize(attrs)
       attrs.each do |attr, value|
@@ -27,10 +28,9 @@ module MyMoip
     end
 
     def owner_birthday=(value)
-      unless value.nil?
-        value = Date.parse(value.to_s)
-      end
-      @owner_birthday = value
+      value = Date.parse(value.to_s) unless value.nil?
+      rescue; ensure
+        @owner_birthday = value
     end
 
     def owner_phone=(value)
@@ -55,5 +55,14 @@ module MyMoip
       end
       @owner_cpf = value
     end
+
+
+    private
+
+      def owner_birthday_format
+        Date.parse(owner_birthday.to_s) unless owner_birthday.nil?
+      rescue ArgumentError
+        errors.add(:owner_birthday)
+      end
   end
 end

--- a/test/lib/test_creditcard.rb
+++ b/test/lib/test_creditcard.rb
@@ -58,10 +58,15 @@ class TestCreditCard < Test::Unit::TestCase
     assert_equal Date.new(1980, 12, 20), subject.owner_birthday
   end
 
-  def test_validate_format_of_birthday_date
+  def test_owner_birthday_accepts_input_of_invalid_dates
     subject = Fixture.credit_card
     subject.owner_birthday = '50/12/1980'
     assert_equal '50/12/1980', subject.owner_birthday
+  end
+
+  def test_validate_format_of_birthday_date
+    subject = Fixture.credit_card
+    subject.owner_birthday = '50/12/1980'
     assert subject.invalid? && subject.errors[:owner_birthday].present?,
       'should be valid'
   end

--- a/test/lib/test_creditcard.rb
+++ b/test/lib/test_creditcard.rb
@@ -58,6 +58,14 @@ class TestCreditCard < Test::Unit::TestCase
     assert_equal Date.new(1980, 12, 20), subject.owner_birthday
   end
 
+  def test_validate_format_of_birthday_date
+    subject = Fixture.credit_card
+    subject.owner_birthday = '50/12/1980'
+    assert_equal '50/12/1980', subject.owner_birthday
+    assert subject.invalid? && subject.errors[:owner_birthday].present?,
+      'should be valid'
+  end
+
   def test_validate_presence_of_security_code_attribute
     subject = Fixture.credit_card
     subject.security_code = nil


### PR DESCRIPTION
When doing this:

``` ruby
credit_card = MyMoip::CreditCard.new(owner_birthday: '80/01/1990')
```

I was getting an `ArgumentError - invalid date` error, but I want to be able to do:

``` ruby
credit_card = MyMoip::CreditCard.new(owner_birthday: '80/01/1990')
if credit_card.valid?
  # do something
else
  # do something else
end
```
