### PR TITLE
Pass opts for super on payment request api call

### DIFF
--- a/lib/mymoip/requests/payment_request.rb
+++ b/lib/mymoip/requests/payment_request.rb
@@ -27,7 +27,7 @@ module MyMoip
       }
       params[:parser] = opts.delete(:parser) unless opts[:parser].nil?
 
-      super(params)
+      super(params, opts)
     end
 
     def success?


### PR DESCRIPTION
I was not able to pass `Rails.logger` as `:logger` option.
