### PR TITLE
Add NASP support

### DIFF
--- a/lib/mymoip/nasp.rb
+++ b/lib/mymoip/nasp.rb
@@ -14,7 +14,7 @@ module MyMoip
     attr_accessor :id, :value, :status, :moip_code, :payment_mode,
                   :payment_method, :installments, :payer_email,
                   :credit_card_first_digits, :credit_card_last_digits,
-                  :credit_card_flag, :moip_vault
+                  :credit_card_flag, :moip_vault, :receiver_login
 
     def initialize(attrs)
       attrs.each do |attr, value|
@@ -50,6 +50,7 @@ module MyMoip
         tipo_pagamento: :payment_method,
         parcelas: :installments,
         email_consumidor: :payer_email,
+        recebedor_login: :receiver_login,
         cartao_bin: :credit_card_first_digits,
         cartao_final: :credit_card_last_digits,
         cartao_bandeira: :credit_card_flag,

--- a/lib/mymoip/nasp.rb
+++ b/lib/mymoip/nasp.rb
@@ -1,0 +1,60 @@
+module MyMoip
+  class Nasp
+    STATUSES = {
+      1 => "Autorizado",
+      2 => "Iniciado",
+      3 => "BoletoImpresso",
+      4 => "Concluido",
+      5 => "Cancelado",
+      6 => "EmAnalise",
+      7 => "Estornado",
+      9 => "Reembolsado"
+    }
+
+    attr_accessor :id, :value, :status, :moip_code, :payment_mode,
+                  :payment_method, :installments, :payer_email,
+                  :credit_card_first_digits, :credit_card_last_digits,
+                  :credit_card_flag, :moip_vault
+
+    def initialize(attrs)
+      attrs.each do |attr, value|
+        public_send(:"#{attr_map(attr)}=", value)
+      end
+    end
+
+    def done?
+      status == 4
+    end
+
+    def canceled?
+      status == 5
+    end
+
+    def reversed?
+      status == 7
+    end
+
+    def refunded?
+      status == 9
+    end
+
+    private
+
+    def attr_map(attr)
+      {
+        id_transacao: :id,
+        valor: :value,
+        status_pagamento: :status,
+        cod_moip: :moip_code,
+        forma_pagamento: :payment_mode,
+        tipo_pagamento: :payment_method,
+        parcelas: :installments,
+        email_consumidor: :payer_email,
+        cartao_bin: :credit_card_first_digits,
+        cartao_final: :credit_card_last_digits,
+        cartao_bandeira: :credit_card_flag,
+        cofre: :moip_vault
+      }.fetch(attr.to_sym)
+    end
+  end
+end

--- a/lib/mymoip/nasp.rb
+++ b/lib/mymoip/nasp.rb
@@ -1,14 +1,14 @@
 module MyMoip
   class Nasp
     STATUSES = {
-      1 => "Autorizado",
-      2 => "Iniciado",
-      3 => "BoletoImpresso",
-      4 => "Concluido",
-      5 => "Cancelado",
-      6 => "EmAnalise",
-      7 => "Estornado",
-      9 => "Reembolsado"
+      "1" => "Autorizado",
+      "2" => "Iniciado",
+      "3" => "BoletoImpresso",
+      "4" => "Concluido",
+      "5" => "Cancelado",
+      "6" => "EmAnalise",
+      "7" => "Estornado",
+      "9" => "Reembolsado"
     }
 
     attr_accessor :id, :value, :status, :moip_code, :payment_mode,
@@ -23,19 +23,19 @@ module MyMoip
     end
 
     def done?
-      status == 4
+      status == "4"
     end
 
     def canceled?
-      status == 5
+      status == "5"
     end
 
     def reversed?
-      status == 7
+      status == "7"
     end
 
     def refunded?
-      status == 9
+      status == "9"
     end
 
     private

--- a/lib/mymoip/nasp.rb
+++ b/lib/mymoip/nasp.rb
@@ -17,6 +17,10 @@ module MyMoip
                   :credit_card_flag, :moip_vault, :receiver_login
 
     def initialize(attrs)
+      # remove rails default params
+      attrs.delete(:controller)
+      attrs.delete(:action)
+
       attrs.each do |attr, value|
         public_send(:"#{attr_map(attr)}=", value)
       end

--- a/test/fixtures/fixture.rb
+++ b/test/fixtures/fixture.rb
@@ -70,4 +70,23 @@ class Fixture
     params = { bank: :itau }.merge(params)
     MyMoip::BankDebit.new(params)
   end
+
+
+  def self.nasp(params = {})
+    params = {
+      id_transacao: "some id",
+      valor: 2350,
+      status_pagamento: 4,
+      cod_moip: 3000,
+      forma_pagamento: 7,
+      tipo_pagamento: "CartaoDeCredito",
+      parcelas: 1,
+      email_consumidor: "joe@mail.com",
+      cartao_bin: "123456",
+      cartao_final: "4321",
+      cartao_bandeira: "AmericanExpress",
+      cofre: "4780c1fb-e47d-448e-ad7b-506c125366fc"
+    }.merge(params)
+    MyMoip::Nasp.new(params)
+  end
 end

--- a/test/lib/test_nasp.rb
+++ b/test/lib/test_nasp.rb
@@ -1,0 +1,95 @@
+require_relative "../test_helper"
+
+class TestPayer < Test::Unit::TestCase
+  def test_getters_for_attributes
+    nasp = MyMoip::Nasp.new(
+      id_transacao: "some id",
+      valor: 2350,
+      status_pagamento: 4,
+      cod_moip: 3000,
+      forma_pagamento: 7,
+      tipo_pagamento: "CartaoDeCredito",
+      parcelas: 1,
+      email_consumidor: "joe@mail.com",
+      cartao_bin: "123456",
+      cartao_final: "4321",
+      cartao_bandeira: "AmericanExpress",
+      cofre: "4780c1fb-e47d-448e-ad7b-506c125366fc"
+    )
+
+    assert_equal "some id", nasp.id
+    assert_equal 2350, nasp.value
+    assert_equal 4, nasp.status
+    assert_equal 3000, nasp.moip_code
+    assert_equal 7, nasp.payment_mode
+    assert_equal "CartaoDeCredito", nasp.payment_method
+    assert_equal 1, nasp.installments
+    assert_equal "joe@mail.com", nasp.payer_email
+    assert_equal "123456", nasp.credit_card_first_digits
+    assert_equal "4321", nasp.credit_card_last_digits
+    assert_equal "AmericanExpress", nasp.credit_card_flag
+    assert_equal "4780c1fb-e47d-448e-ad7b-506c125366fc", nasp.moip_vault
+  end
+
+  def test_initialization_and_setters_with_string_keys
+    nasp = MyMoip::Nasp.new(
+      "id_transacao" => "some id",
+      "valor" => 2350,
+      "status_pagamento" => 4,
+      "cod_moip" => 3000,
+      "forma_pagamento" => 7,
+      "tipo_pagamento" => "CartaoDeCredito",
+      "parcelas" => 1,
+      "email_consumidor" => "joe@mail.com",
+      "cartao_bin" => "123456",
+      "cartao_final" => "4321",
+      "cartao_bandeira" => "AmericanExpress",
+      "cofre" => "4780c1fb-e47d-448e-ad7b-506c125366fc"
+    )
+
+    assert_equal "some id", nasp.id
+    assert_equal 2350, nasp.value
+    assert_equal 4, nasp.status
+    assert_equal 3000, nasp.moip_code
+    assert_equal 7, nasp.payment_mode
+    assert_equal "CartaoDeCredito", nasp.payment_method
+    assert_equal 1, nasp.installments
+    assert_equal "joe@mail.com", nasp.payer_email
+    assert_equal "123456", nasp.credit_card_first_digits
+    assert_equal "4321", nasp.credit_card_last_digits
+    assert_equal "AmericanExpress", nasp.credit_card_flag
+    assert_equal "4780c1fb-e47d-448e-ad7b-506c125366fc", nasp.moip_vault
+  end
+
+  def test_if_status_is_done
+    nasp = Fixture.nasp(status_pagamento: 4)
+    assert_equal nasp.done?, true
+
+    nasp = Fixture.nasp(status_pagamento: 3)
+    assert_equal nasp.done?, false
+  end
+
+  def test_if_status_is_canceled
+    nasp = Fixture.nasp(status_pagamento: 5)
+    assert_equal nasp.canceled?, true
+
+    nasp = Fixture.nasp(status_pagamento: 3)
+    assert_equal nasp.canceled?, false
+  end
+
+  def test_if_status_is_reversed
+    nasp = Fixture.nasp(status_pagamento: 7)
+    assert_equal nasp.reversed?, true
+
+    nasp = Fixture.nasp(status_pagamento: 3)
+    assert_equal nasp.reversed?, false
+  end
+
+  def test_if_status_is_refunded
+    nasp = Fixture.nasp(status_pagamento: 9)
+    assert_equal nasp.refunded?, true
+
+    nasp = Fixture.nasp(status_pagamento: 3)
+    assert_equal nasp.refunded?, false
+  end
+end

--- a/test/lib/test_nasp.rb
+++ b/test/lib/test_nasp.rb
@@ -65,6 +65,15 @@ class TestPayer < Test::Unit::TestCase
     assert_equal "4780c1fb-e47d-448e-ad7b-506c125366fc", nasp.moip_vault
   end
 
+  def test_if_ignore_rails_default_params
+    nasp = MyMoip::Nasp.new(
+      id_transacao: "some id",
+      controller: "moip",
+      action: "nasp"
+    )
+    assert_equal "some id", nasp.id
+  end
+
   def test_if_status_is_done
     nasp = Fixture.nasp(status_pagamento: "4")
     assert_equal nasp.done?, true

--- a/test/lib/test_nasp.rb
+++ b/test/lib/test_nasp.rb
@@ -4,12 +4,12 @@ class TestPayer < Test::Unit::TestCase
   def test_getters_for_attributes
     nasp = MyMoip::Nasp.new(
       id_transacao: "some id",
-      valor: 2350,
-      status_pagamento: 4,
-      cod_moip: 3000,
-      forma_pagamento: 7,
+      valor: "2350",
+      status_pagamento: "4",
+      cod_moip: "3000",
+      forma_pagamento: "7",
       tipo_pagamento: "CartaoDeCredito",
-      parcelas: 1,
+      parcelas: "1",
       email_consumidor: "joe@mail.com",
       recebedor_login: "someMoipLogin",
       cartao_bin: "123456",
@@ -19,12 +19,12 @@ class TestPayer < Test::Unit::TestCase
     )
 
     assert_equal "some id", nasp.id
-    assert_equal 2350, nasp.value
-    assert_equal 4, nasp.status
-    assert_equal 3000, nasp.moip_code
-    assert_equal 7, nasp.payment_mode
+    assert_equal "2350", nasp.value
+    assert_equal "4", nasp.status
+    assert_equal "3000", nasp.moip_code
+    assert_equal "7", nasp.payment_mode
     assert_equal "CartaoDeCredito", nasp.payment_method
-    assert_equal 1, nasp.installments
+    assert_equal "1", nasp.installments
     assert_equal "joe@mail.com", nasp.payer_email
     assert_equal "someMoipLogin", nasp.receiver_login
     assert_equal "123456", nasp.credit_card_first_digits
@@ -36,12 +36,12 @@ class TestPayer < Test::Unit::TestCase
   def test_initialization_and_setters_with_string_keys
     nasp = MyMoip::Nasp.new(
       "id_transacao" => "some id",
-      "valor" => 2350,
-      "status_pagamento" => 4,
-      "cod_moip" => 3000,
-      "forma_pagamento" => 7,
+      "valor" => "2350",
+      "status_pagamento" => "4",
+      "cod_moip" => "3000",
+      "forma_pagamento" => "7",
       "tipo_pagamento" => "CartaoDeCredito",
-      "parcelas" => 1,
+      "parcelas" => "1",
       "email_consumidor" => "joe@mail.com",
       "recebedor_login" => "someMoipLogin",
       "cartao_bin" => "123456",
@@ -51,12 +51,12 @@ class TestPayer < Test::Unit::TestCase
     )
 
     assert_equal "some id", nasp.id
-    assert_equal 2350, nasp.value
-    assert_equal 4, nasp.status
-    assert_equal 3000, nasp.moip_code
-    assert_equal 7, nasp.payment_mode
+    assert_equal "2350", nasp.value
+    assert_equal "4", nasp.status
+    assert_equal "3000", nasp.moip_code
+    assert_equal "7", nasp.payment_mode
     assert_equal "CartaoDeCredito", nasp.payment_method
-    assert_equal 1, nasp.installments
+    assert_equal "1", nasp.installments
     assert_equal "joe@mail.com", nasp.payer_email
     assert_equal "someMoipLogin", nasp.receiver_login
     assert_equal "123456", nasp.credit_card_first_digits
@@ -66,34 +66,34 @@ class TestPayer < Test::Unit::TestCase
   end
 
   def test_if_status_is_done
-    nasp = Fixture.nasp(status_pagamento: 4)
+    nasp = Fixture.nasp(status_pagamento: "4")
     assert_equal nasp.done?, true
 
-    nasp = Fixture.nasp(status_pagamento: 3)
+    nasp = Fixture.nasp(status_pagamento: "3")
     assert_equal nasp.done?, false
   end
 
   def test_if_status_is_canceled
-    nasp = Fixture.nasp(status_pagamento: 5)
+    nasp = Fixture.nasp(status_pagamento: "5")
     assert_equal nasp.canceled?, true
 
-    nasp = Fixture.nasp(status_pagamento: 3)
+    nasp = Fixture.nasp(status_pagamento: "3")
     assert_equal nasp.canceled?, false
   end
 
   def test_if_status_is_reversed
-    nasp = Fixture.nasp(status_pagamento: 7)
+    nasp = Fixture.nasp(status_pagamento: "7")
     assert_equal nasp.reversed?, true
 
-    nasp = Fixture.nasp(status_pagamento: 3)
+    nasp = Fixture.nasp(status_pagamento: "3")
     assert_equal nasp.reversed?, false
   end
 
   def test_if_status_is_refunded
-    nasp = Fixture.nasp(status_pagamento: 9)
+    nasp = Fixture.nasp(status_pagamento: "9")
     assert_equal nasp.refunded?, true
 
-    nasp = Fixture.nasp(status_pagamento: 3)
+    nasp = Fixture.nasp(status_pagamento: "3")
     assert_equal nasp.refunded?, false
   end
 end

--- a/test/lib/test_nasp.rb
+++ b/test/lib/test_nasp.rb
@@ -11,6 +11,7 @@ class TestPayer < Test::Unit::TestCase
       tipo_pagamento: "CartaoDeCredito",
       parcelas: 1,
       email_consumidor: "joe@mail.com",
+      recebedor_login: "someMoipLogin",
       cartao_bin: "123456",
       cartao_final: "4321",
       cartao_bandeira: "AmericanExpress",
@@ -25,6 +26,7 @@ class TestPayer < Test::Unit::TestCase
     assert_equal "CartaoDeCredito", nasp.payment_method
     assert_equal 1, nasp.installments
     assert_equal "joe@mail.com", nasp.payer_email
+    assert_equal "someMoipLogin", nasp.receiver_login
     assert_equal "123456", nasp.credit_card_first_digits
     assert_equal "4321", nasp.credit_card_last_digits
     assert_equal "AmericanExpress", nasp.credit_card_flag
@@ -41,6 +43,7 @@ class TestPayer < Test::Unit::TestCase
       "tipo_pagamento" => "CartaoDeCredito",
       "parcelas" => 1,
       "email_consumidor" => "joe@mail.com",
+      "recebedor_login" => "someMoipLogin",
       "cartao_bin" => "123456",
       "cartao_final" => "4321",
       "cartao_bandeira" => "AmericanExpress",
@@ -55,6 +58,7 @@ class TestPayer < Test::Unit::TestCase
     assert_equal "CartaoDeCredito", nasp.payment_method
     assert_equal 1, nasp.installments
     assert_equal "joe@mail.com", nasp.payer_email
+    assert_equal "someMoipLogin", nasp.receiver_login
     assert_equal "123456", nasp.credit_card_first_digits
     assert_equal "4321", nasp.credit_card_last_digits
     assert_equal "AmericanExpress", nasp.credit_card_flag


### PR DESCRIPTION
This is not for you to accept, is just an idea, to use it like this in a Rails app:

``` ruby
class MoipController < ApplicationController
  skip_before_filter :verify_authenticity_token, only: [:nasp]

  # controller method that receives Moip NASP POST
  def nasp
    nasp = MyMoip::Nasp.new(params)

    invoice = Invoice.find(nasp.id)
    invoice.update_attribute(:status, nasp.status)

    if nasp.done?
      # do something
    end

    render nothing: true
  end
end
```

What you think about it? 
